### PR TITLE
fix: Stop ball movement on hole detection

### DIFF
--- a/script.js
+++ b/script.js
@@ -328,6 +328,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (distToHole < HOLE_RADIUS && Math.hypot(ballVel.x, ballVel.y) < 2) { // The center of the ball is over the hole and the speed is low
             isMoving = false;
+            ballVel = { x: 0, y: 0 };
             cancelAnimationFrame(animationFrameId);
             const holePar = holeData[currentHoleIndex].par;
             let scoreMsg = "";


### PR DESCRIPTION
This commit ensures that the ball stops moving immediately upon being detected in the hole.

The `ballVel` (ball velocity) is now explicitly set to `{ x: 0, y: 0 }` inside the hole detection condition. This prevents any residual velocity from causing the ball to move after it has entered the hole, leading to a cleaner and more predictable game experience.