### PR TITLE
fix: Restore showMessage function after canvas rewrite

### DIFF
--- a/script.js
+++ b/script.js
@@ -301,6 +301,15 @@ document.addEventListener('DOMContentLoaded', () => {
         if (shape.type === 'oval') return (Math.pow(point.x - shape.cx, 2) / Math.pow(shape.rx, 2) + Math.pow(point.y - shape.cy, 2) / Math.pow(shape.ry, 2) < 1);
         return false;
     }
+    function showMessage(msg, type = 'info') {
+        messageAreaElement.textContent = msg;
+        messageAreaElement.className = 'message-area'; // Reset classes
+        if (type === 'success') {
+            messageAreaElement.classList.add('success');
+        } else if (type === 'penalty') {
+            messageAreaElement.classList.add('penalty');
+        }
+    }
     function getTerrainAtPoint(point) {
         const terrains = [];
         for (const shape of allPhysicsShapes) {


### PR DESCRIPTION
This commit fixes a regression that was introduced during the major rewrite to the canvas-based rendering engine. The `showMessage` function, which is responsible for displaying all game status messages in the UI, was accidentally removed.

This commit re-implements the `showMessage` function, restoring the display of critical game information like "In play!", "Ready for stroke...", and penalty messages. The game is now fully playable again.